### PR TITLE
chore(rpc): re-optimize endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ resolver = "2"
 
 [workspace.package]
 version = "0.8.2"
-edition = "2021"
-rust-version = "1.82"
+edition = "2024"
+rust-version = "1.88"
 authors = ["init4"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/init4tech/signet-sdk"

--- a/crates/blobber/src/block_data.rs
+++ b/crates/blobber/src/block_data.rs
@@ -1,11 +1,11 @@
 use crate::{
-    error::UnrecoverableBlobError, shim::ExtractableChainShim, BlockExtractionError,
-    BlockExtractorBuilder, ExtractionResult,
+    BlockExtractionError, BlockExtractorBuilder, ExtractionResult, error::UnrecoverableBlobError,
+    shim::ExtractableChainShim,
 };
 use alloy::{
     consensus::{Blob, SidecarCoder, SimpleCoder},
     eips::eip7594::BlobTransactionSidecarVariant,
-    primitives::{keccak256, TxHash, B256},
+    primitives::{B256, TxHash, keccak256},
 };
 use init4_bin_base::utils::calc::SlotCalculator;
 use reth::{
@@ -334,15 +334,15 @@ mod tests {
             BlobTransactionSidecar, SidecarBuilder, SignableTransaction, TxEip2930, TxEnvelope,
         },
         eips::Encodable2718,
-        primitives::{bytes, Address, TxKind, U256},
+        primitives::{Address, TxKind, U256, bytes},
         rlp::encode,
-        signers::{local::PrivateKeySigner, SignerSync},
+        signers::{SignerSync, local::PrivateKeySigner},
     };
     use foundry_blob_explorers::TransactionDetails;
     use reth::primitives::{Transaction, TransactionSigned};
     use reth_transaction_pool::{
-        test_utils::{testing_pool, MockTransaction},
         PoolTransaction, TransactionOrigin,
+        test_utils::{MockTransaction, testing_pool},
     };
     use signet_types::constants::SignetSystemConstants;
 

--- a/crates/blobber/src/builder.rs
+++ b/crates/blobber/src/builder.rs
@@ -1,4 +1,4 @@
-use crate::{block_data::BlockExtractor, BlockExtractorConfig};
+use crate::{BlockExtractorConfig, block_data::BlockExtractor};
 use init4_bin_base::utils::calc::SlotCalculator;
 use reth::transaction_pool::TransactionPool;
 use url::Url;

--- a/crates/db/src/provider.rs
+++ b/crates/db/src/provider.rs
@@ -1,11 +1,11 @@
 use crate::{
+    DataCompat, DbZenithHeader, RuChain, ZenithHeaders,
     tables::{DbSignetEvent, JournalHashes, SignetEvents},
     traits::RuWriter,
-    DataCompat, DbZenithHeader, RuChain, ZenithHeaders,
 };
 use alloy::{
     consensus::{BlockHeader, TxReceipt},
-    primitives::{map::HashSet, Address, BlockNumber, B256, U256},
+    primitives::{Address, B256, BlockNumber, U256, map::HashSet},
 };
 use reth::{
     primitives::{Account, StaticFileSegment},
@@ -17,13 +17,13 @@ use reth::{
     },
 };
 use reth_db::{
+    PlainAccountState,
     cursor::{DbCursorRO, DbCursorRW},
     models::{BlockNumberAddress, StoredBlockBodyIndices},
     tables,
     transaction::{DbTx, DbTxMut},
-    PlainAccountState,
 };
-use reth_prune_types::{PruneMode, MINIMUM_PRUNING_DISTANCE};
+use reth_prune_types::{MINIMUM_PRUNING_DISTANCE, PruneMode};
 use signet_evm::BlockResult;
 use signet_node_types::{NodeTypesDbTrait, SignetNodeTypes};
 use signet_types::primitives::RecoveredBlock;

--- a/crates/db/src/tables.rs
+++ b/crates/db/src/tables.rs
@@ -1,10 +1,11 @@
 use alloy::{
-    primitives::{bytes::BufMut, Address, BlockNumber, Bytes, B256, U256},
+    primitives::{Address, B256, BlockNumber, Bytes, U256, bytes::BufMut},
     rlp::Buf,
 };
 use reth_db::{
+    DatabaseError,
     table::{Compress, Decompress, DupSort, Table},
-    tables, DatabaseError,
+    tables,
 };
 use signet_zenith::{
     Passage::{Enter, EnterToken},

--- a/crates/db/src/traits.rs
+++ b/crates/db/src/traits.rs
@@ -1,5 +1,5 @@
 use crate::{DbExtractionResults, DbSignetEvent, RuChain};
-use alloy::primitives::{Address, BlockNumber, B256, U256};
+use alloy::primitives::{Address, B256, BlockNumber, U256};
 use itertools::Itertools;
 use reth::{
     primitives::Account,

--- a/crates/rpc/examples/filler.rs
+++ b/crates/rpc/examples/filler.rs
@@ -3,16 +3,16 @@ use alloy::{
     network::{Ethereum, EthereumWallet, TransactionBuilder},
     primitives::Bytes,
     providers::{
+        Identity, Provider as _, RootProvider, SendableTx,
         fillers::{
             BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
             WalletFiller,
         },
-        Identity, Provider as _, RootProvider, SendableTx,
     },
-    rpc::types::{mev::EthSendBundle, TransactionRequest},
+    rpc::types::{TransactionRequest, mev::EthSendBundle},
     signers::Signer,
 };
-use eyre::{eyre, Error};
+use eyre::{Error, eyre};
 use signet_bundle::SignetEthBundle;
 use signet_constants::SignetConstants;
 use signet_tx_cache::{client::TxCache, types::TxCacheSendBundleResponse};

--- a/crates/rpc/examples/order.rs
+++ b/crates/rpc/examples/order.rs
@@ -1,11 +1,11 @@
 use alloy::{
     consensus::constants::GWEI_TO_WEI,
-    primitives::{uint, U256},
+    primitives::{U256, uint},
     signers::Signer,
 };
 use chrono::Utc;
 use eyre::Error;
-use signet_constants::{SignetConstants, NATIVE_TOKEN_ADDRESS};
+use signet_constants::{NATIVE_TOKEN_ADDRESS, SignetConstants};
 use signet_tx_cache::client::TxCache;
 use signet_types::UnsignedOrder;
 use signet_zenith::RollupOrders::{Input, Order, Output};

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -1,4 +1,4 @@
-use ajj::{pubsub::ServerShutdown, Router};
+use ajj::{Router, pubsub::ServerShutdown};
 use reth::{args::RpcServerArgs, tasks::TaskExecutor};
 use std::net::SocketAddr;
 use tokio::task::JoinHandle;

--- a/crates/rpc/src/ctx.rs
+++ b/crates/rpc/src/ctx.rs
@@ -1,9 +1,9 @@
 use crate::{
+    Pnt,
     eth::EthError,
     interest::{ActiveFilter, FilterManager, FilterOutput, SubscriptionManager},
     receipts::build_signet_receipt,
     util::BlockRangeInclusiveIter,
-    Pnt,
 };
 use alloy::{
     consensus::{BlockHeader, Header, Signed, Transaction, TxEnvelope},
@@ -16,21 +16,21 @@ use reth::{
     core::primitives::SignerRecoverable,
     primitives::{Block, EthPrimitives, Receipt, Recovered, RecoveredBlock, TransactionSigned},
     providers::{
-        providers::{BlockchainProvider, ProviderNodeTypes},
         BlockHashReader, BlockIdReader, BlockNumReader, CanonStateSubscriptions, HeaderProvider,
         ProviderBlock, ProviderError, ProviderReceipt, ReceiptProvider, StateProviderFactory,
         TransactionsProvider,
+        providers::{BlockchainProvider, ProviderNodeTypes},
     },
     revm::{database::StateProviderDatabase, primitives::hardfork::SpecId},
     rpc::{
         eth::{filter::EthFilterError, helpers::types::EthRpcConverter},
         server_types::eth::{
+            EthApiError, EthConfig, EthStateCache, FeeHistoryCache, FeeHistoryEntry,
+            GasPriceOracle,
             fee_history::{
                 calculate_reward_percentiles_for_block, fee_history_cache_new_blocks_task,
             },
-            logs_utils::{self, append_matching_block_logs, ProviderOrBlock},
-            EthApiError, EthConfig, EthStateCache, FeeHistoryCache, FeeHistoryEntry,
-            GasPriceOracle,
+            logs_utils::{self, ProviderOrBlock, append_matching_block_logs},
         },
         types::{FilterBlockOption, FilteredParams},
     },
@@ -41,12 +41,12 @@ use reth_node_api::{BlockBody, FullNodeComponents};
 use reth_rpc_eth_api::{RpcBlock, RpcConvert, RpcReceipt, RpcTransaction};
 use signet_evm::EvmNeedsTx;
 use signet_tx_cache::client::TxCache;
-use signet_types::{constants::SignetSystemConstants, MagicSig};
+use signet_types::{MagicSig, constants::SignetSystemConstants};
 use std::{marker::PhantomData, sync::Arc};
-use tracing::{instrument, trace, Level};
+use tracing::{Level, instrument, trace};
 use trevm::{
-    revm::{context::CfgEnv, database::StateBuilder},
     Cfg,
+    revm::{context::CfgEnv, database::StateBuilder},
 };
 
 /// Type alias for EVMs using a [`StateProviderBox`] as the `DB` type for
@@ -325,7 +325,6 @@ where
 
         Ok(Some((hash, header)))
     }
-
 
     /// Get the block for a given block, returning the block hash and
     /// the block itself.

--- a/crates/rpc/src/ctx.rs
+++ b/crates/rpc/src/ctx.rs
@@ -312,6 +312,21 @@ where
         Ok(builder.build())
     }
 
+    /// Get the [`Header`] for a given block.
+    pub async fn raw_header(
+        &self,
+        t: impl Into<BlockId>,
+    ) -> Result<Option<(B256, Header)>, EthApiError> {
+        let Some(hash) = self.provider.block_hash_for_id(t.into())? else {
+            return Ok(None);
+        };
+
+        let header = self.cache.get_header(hash).await.map_err(EthApiError::from)?;
+
+        Ok(Some((hash, header)))
+    }
+
+
     /// Get the block for a given block, returning the block hash and
     /// the block itself.
     pub async fn raw_block(
@@ -513,7 +528,7 @@ where
         build_signet_receipt(tx, meta, receipt, all_receipts.to_vec()).map(Some)
     }
 
-    /// Create the [`Block`] object for a specific [`BlockId`].
+    /// Create the [`Header`] object for a specific [`BlockId`].
     pub async fn block_cfg(&self, mut block_id: BlockId) -> Result<Header, EthApiError> {
         // If the block is pending, we'll load the latest and
         let pending = block_id.is_pending();
@@ -521,11 +536,9 @@ where
             block_id = BlockId::latest();
         }
 
-        let Some((_, block)) = self.raw_block(block_id).await? else {
+        let Some((_, mut header)) = self.raw_header(block_id).await? else {
             return Err(EthApiError::HeaderNotFound(block_id));
         };
-
-        let mut header = block.clone_header();
 
         // Modify the header for pending blocks, to simulate the next block.
         if pending {

--- a/crates/rpc/src/eth/mod.rs
+++ b/crates/rpc/src/eth/mod.rs
@@ -7,7 +7,7 @@ pub use error::EthError;
 mod helpers;
 pub use helpers::CallErrorData;
 
-use crate::{ctx::RpcCtx, Pnt};
+use crate::{Pnt, ctx::RpcCtx};
 use alloy::{eips::BlockNumberOrTag, primitives::B256};
 use reth_node_api::FullNodeComponents;
 

--- a/crates/rpc/src/interest/kind.rs
+++ b/crates/rpc/src/interest/kind.rs
@@ -96,11 +96,7 @@ impl InterestKind {
         &self,
         notif: &CanonStateNotification,
     ) -> SubscriptionBuffer {
-        if self.is_block() {
-            self.apply_block(notif)
-        } else {
-            self.apply_filter(notif)
-        }
+        if self.is_block() { self.apply_block(notif) } else { self.apply_filter(notif) }
     }
 
     /// Return an empty output of the same kind as this filter.

--- a/crates/rpc/src/interest/subs.rs
+++ b/crates/rpc/src/interest/subs.rs
@@ -1,9 +1,9 @@
-use crate::{interest::InterestKind, Pnt};
-use ajj::{serde_json, HandlerCtx};
+use crate::{Pnt, interest::InterestKind};
+use ajj::{HandlerCtx, serde_json};
 use alloy::{primitives::U64, rpc::types::Log};
 use dashmap::DashMap;
 use reth::{
-    providers::{providers::BlockchainProvider, CanonStateNotifications, CanonStateSubscriptions},
+    providers::{CanonStateNotifications, CanonStateSubscriptions, providers::BlockchainProvider},
     rpc::types::Header,
 };
 use std::{
@@ -11,14 +11,14 @@ use std::{
     collections::VecDeque,
     future::pending,
     sync::{
-        atomic::{AtomicU64, Ordering},
         Arc, Weak,
+        atomic::{AtomicU64, Ordering},
     },
     time::Duration,
 };
 use tokio::sync::broadcast::error::RecvError;
 use tokio_util::sync::{CancellationToken, WaitForCancellationFutureOwned};
-use tracing::{debug, debug_span, enabled, trace, Instrument};
+use tracing::{Instrument, debug, debug_span, enabled, trace};
 
 /// Either type for subscription outputs.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
@@ -350,10 +350,12 @@ impl<N: Pnt> SubCleanerTask<N> {
     /// [`DashMap::retain`]'s deadlock condition is not met. See [`DashMap`]
     /// documentation for more information.
     pub(super) fn spawn(self) {
-        std::thread::spawn(move || loop {
-            std::thread::sleep(self.interval);
-            if let Some(inner) = self.inner.upgrade() {
-                inner.tasks.retain(|_, task| !task.is_cancelled());
+        std::thread::spawn(move || {
+            loop {
+                std::thread::sleep(self.interval);
+                if let Some(inner) = self.inner.upgrade() {
+                    inner.tasks.retain(|_, task| !task.is_cancelled());
+                }
             }
         });
     }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -55,7 +55,7 @@ mod ctx;
 pub use ctx::{RpcCtx, RuRevmState};
 
 mod eth;
-pub use eth::{eth, CallErrorData, EthError};
+pub use eth::{CallErrorData, EthError, eth};
 
 mod signet;
 pub use signet::{error::SignetError, signet};

--- a/crates/rpc/src/receipts.rs
+++ b/crates/rpc/src/receipts.rs
@@ -1,7 +1,7 @@
 //! Signet RPC receipt response builder.
 
 use alloy::consensus::Transaction;
-use alloy::consensus::{transaction::TransactionMeta, ReceiptEnvelope, TxReceipt};
+use alloy::consensus::{ReceiptEnvelope, TxReceipt, transaction::TransactionMeta};
 use alloy::primitives::{Address, TxKind};
 use alloy::rpc::types::eth::{Log, ReceiptWithBloom, TransactionReceipt};
 use reth::core::primitives::SignerRecoverable;

--- a/crates/rpc/src/signet/endpoints.rs
+++ b/crates/rpc/src/signet/endpoints.rs
@@ -1,8 +1,8 @@
 use crate::{
+    Pnt,
     ctx::RpcCtx,
     signet::error::SignetError,
     util::{await_jh_option, await_jh_option_response, response_tri},
-    Pnt,
 };
 use ajj::{HandlerCtx, ResponsePayload};
 use reth_node_api::FullNodeComponents;
@@ -76,7 +76,7 @@ where
                 return ResponsePayload::internal_error_with_message_and_obj(
                     "error while loading block cfg".into(),
                     e.to_string(),
-                )
+                );
             }
         };
 

--- a/crates/rpc/src/signet/mod.rs
+++ b/crates/rpc/src/signet/mod.rs
@@ -5,7 +5,7 @@ use endpoints::*;
 
 pub(crate) mod error;
 
-use crate::{ctx::RpcCtx, Pnt};
+use crate::{Pnt, ctx::RpcCtx};
 use reth_node_api::FullNodeComponents;
 
 /// Instantiate a `signet` API router.

--- a/crates/rpc/src/util.rs
+++ b/crates/rpc/src/util.rs
@@ -1,6 +1,6 @@
 use ajj::{
-    pubsub::{Connect, ServerShutdown},
     Router,
+    pubsub::{Connect, ServerShutdown},
 };
 use axum::http::HeaderValue;
 use interprocess::local_socket as ls;


### PR DESCRIPTION
chore(rpc): re-optimize endpoints

Seems this was not included when migrating out of the SDK.

chore(repo): clippy / fmt

With the new edition/version bump there's a bunch of clippy / fmt changes to do.