### PR TITLE
fix(db): use ru height for history indices & events instead of using the host block number

### DIFF
--- a/crates/db/src/provider.rs
+++ b/crates/db/src/provider.rs
@@ -82,14 +82,20 @@ where
         index: u64,
         enter_token: EnterToken,
     ) -> ProviderResult<()> {
-        self.tx_ref().put::<SignetEvents>(ru_height, DbSignetEvent::EnterToken(index, enter_token))?;
+        self.tx_ref()
+            .put::<SignetEvents>(ru_height, DbSignetEvent::EnterToken(index, enter_token))?;
         Ok(())
     }
 
     /// Insert a Transact into the DB
     /// This is a signet-specific function that inserts a transact event into the
     /// [`SignetEvents`] table.
-    fn insert_transact(&self, ru_height: u64, index: u64, transact: &Transact) -> ProviderResult<()> {
+    fn insert_transact(
+        &self,
+        ru_height: u64,
+        index: u64,
+        transact: &Transact,
+    ) -> ProviderResult<()> {
         // this is unfortunate, but probably fine because the large part is the
         // shared Bytes object.
         let t = transact.clone();


### PR DESCRIPTION
fix(db): update ru history indices instead of using the host block number

This will cause issues since we're not providing the correct number for changeset updates on the L2.

fix(db): Insert enters to `SignetEvents` table with their RU height

chore(db): rename every ambiguous height parameter to ru height or host, where appropriate