### PR TITLE
perf(rpc): use `CacheDB` for wrapping `StateProviderDatabase`

### DIFF
--- a/crates/rpc/src/ctx.rs
+++ b/crates/rpc/src/ctx.rs
@@ -21,7 +21,7 @@ use reth::{
         TransactionsProvider,
         providers::{BlockchainProvider, ProviderNodeTypes},
     },
-    revm::{database::StateProviderDatabase, primitives::hardfork::SpecId},
+    revm::{database::StateProviderDatabase, db::CacheDB, primitives::hardfork::SpecId},
     rpc::{
         eth::{filter::EthFilterError, helpers::types::EthRpcConverter},
         server_types::eth::{
@@ -54,7 +54,9 @@ use trevm::{
 ///
 /// [`StateProviderBox`]: reth::providers::StateProviderBox
 pub type RuRevmState = trevm::revm::database::State<
-    reth::revm::database::StateProviderDatabase<reth::providers::StateProviderBox>,
+    reth::revm::db::CacheDB<
+        reth::revm::database::StateProviderDatabase<reth::providers::StateProviderBox>,
+    >,
 >;
 
 /// The maximum number of headers we read at once when handling a range filter.
@@ -305,7 +307,7 @@ where
         let sp = self.provider.history_by_block_number(height)?;
 
         // Wrap in Revm compatibility layer
-        let spd = StateProviderDatabase::new(sp);
+        let spd = CacheDB::new(StateProviderDatabase::new(sp));
 
         let builder = StateBuilder::new_with_database(spd);
 


### PR DESCRIPTION
Reth also does this [e.g](https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc/src/eth/bundle.rs#L151).

This makes sense, as for RPC we're only accessing state and more complex calls might need accessing the same parts of the trie. We can save a bunch of I/O time by caching the results (and state changes when tracing, which once implemented should be faster with this layer).