### PR TITLE
feat(host-reth): replace ExEx backfill with direct DB reads

### DIFF
--- a/crates/host-reth/Cargo.toml
+++ b/crates/host-reth/Cargo.toml
@@ -22,7 +22,6 @@ alloy.workspace = true
 reth.workspace = true
 reth-exex.workspace = true
 reth-node-api.workspace = true
-reth-stages-types.workspace = true
 
 futures-util.workspace = true
 metrics.workspace = true

--- a/crates/host-reth/Cargo.toml
+++ b/crates/host-reth/Cargo.toml
@@ -25,6 +25,7 @@ reth-node-api.workspace = true
 reth-stages-types.workspace = true
 
 futures-util.workspace = true
+metrics.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/host-reth/src/backfill.rs
+++ b/crates/host-reth/src/backfill.rs
@@ -22,7 +22,7 @@ pub(crate) struct DbBlock {
     receipts: Vec<Receipt>,
 }
 
-/// A contiguous segment of [`DbBlock`]s read from the reth DB.
+/// A contiguous segment of blocks read from the reth DB.
 ///
 /// Implements [`Extractable`] using the same `RecoveredBlockShim` transmute
 /// pattern as [`RethChain`](crate::RethChain).

--- a/crates/host-reth/src/backfill.rs
+++ b/crates/host-reth/src/backfill.rs
@@ -97,6 +97,11 @@ impl<P> DbBackfill<P> {
         self.batch_size = batch_size.max(1);
     }
 
+    /// Reset the batch size to the default.
+    pub(crate) const fn reset_batch_size(&mut self) {
+        self.batch_size = DEFAULT_BATCH_SIZE;
+    }
+
     /// Current cursor position (next block to fetch).
     pub(crate) const fn cursor(&self) -> u64 {
         self.cursor

--- a/crates/host-reth/src/backfill.rs
+++ b/crates/host-reth/src/backfill.rs
@@ -1,0 +1,196 @@
+#![allow(dead_code)] // used in subsequent tasks (HostChain enum, RethHostNotifier rewrite)
+
+use crate::{RecoveredBlockShim, error::RethHostError, metrics};
+use alloy::consensus::{Block, BlockHeader};
+use reth::primitives::{Receipt, RecoveredBlock};
+use reth::providers::{
+    BlockIdReader, BlockReader, HeaderProvider, ReceiptProvider, TransactionVariant,
+};
+use signet_extract::{BlockAndReceipts, Extractable};
+use signet_types::primitives::TransactionSigned;
+use std::time::Instant;
+use tracing::{debug, instrument};
+
+/// Default number of blocks fetched per [`DbBackfill`] batch.
+const DEFAULT_BATCH_SIZE: u64 = 1000;
+
+/// Reth's recovered block type, aliased for readability.
+type RethRecovered = RecoveredBlock<Block<TransactionSigned>>;
+
+/// An owned block and its receipts, read from the reth DB.
+#[derive(Debug)]
+pub(crate) struct DbBlock {
+    block: RethRecovered,
+    receipts: Vec<Receipt>,
+}
+
+/// A contiguous segment of [`DbBlock`]s read from the reth DB.
+///
+/// Implements [`Extractable`] using the same `RecoveredBlockShim` transmute
+/// pattern as [`RethChain`](crate::RethChain).
+#[derive(Debug)]
+pub(crate) struct DbChainSegment(Vec<DbBlock>);
+
+impl Extractable for DbChainSegment {
+    type Block = RecoveredBlockShim;
+    type Receipt = Receipt;
+
+    fn blocks_and_receipts(
+        &self,
+    ) -> impl Iterator<Item = BlockAndReceipts<'_, Self::Block, Self::Receipt>> {
+        self.0.iter().map(|db_block| {
+            // Compile-time check: RecoveredBlockShim must have the same
+            // layout as RethRecovered (guaranteed by #[repr(transparent)]
+            // on RecoveredBlockShim in shim.rs).
+            const {
+                assert!(
+                    size_of::<RecoveredBlockShim>() == size_of::<RethRecovered>(),
+                    "RecoveredBlockShim layout diverged from RethRecovered"
+                );
+                assert!(
+                    align_of::<RecoveredBlockShim>() == align_of::<RethRecovered>(),
+                    "RecoveredBlockShim alignment diverged from RethRecovered"
+                );
+            }
+            // SAFETY: `RecoveredBlockShim` is `#[repr(transparent)]` over
+            // `RethRecovered`, so these types have identical memory layouts.
+            // The lifetime of the reference is tied to `db_block`, which
+            // outlives the returned iterator item.
+            let block = unsafe {
+                std::mem::transmute::<&RethRecovered, &RecoveredBlockShim>(&db_block.block)
+            };
+            BlockAndReceipts { block, receipts: &db_block.receipts }
+        })
+    }
+
+    fn first_number(&self) -> u64 {
+        self.0.first().map(|b| b.block.number()).expect("DbChainSegment must be non-empty")
+    }
+
+    fn tip_number(&self) -> u64 {
+        self.0.last().map(|b| b.block.number()).expect("DbChainSegment must be non-empty")
+    }
+
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+/// Reads blocks and receipts from the reth DB provider in batches.
+///
+/// Starting from a cursor block number, each call to [`DbBackfill::next_batch`]
+/// fetches up to `batch_size` blocks (default: 1000) up to and including the
+/// current finalized block. Returns `None` when the cursor exceeds finalized.
+#[derive(Debug)]
+pub(crate) struct DbBackfill<P> {
+    provider: P,
+    cursor: u64,
+    batch_size: u64,
+}
+
+impl<P> DbBackfill<P> {
+    /// Create a new `DbBackfill` starting at `cursor` with the default batch size.
+    pub(crate) const fn new(provider: P, cursor: u64) -> Self {
+        Self { provider, cursor, batch_size: DEFAULT_BATCH_SIZE }
+    }
+
+    /// Set the batch size (minimum 1).
+    pub(crate) fn set_batch_size(&mut self, batch_size: u64) {
+        self.batch_size = batch_size.max(1);
+    }
+
+    /// Current cursor position (next block to fetch).
+    pub(crate) const fn cursor(&self) -> u64 {
+        self.cursor
+    }
+}
+
+impl<P> DbBackfill<P>
+where
+    P: BlockReader<Block = Block<TransactionSigned>>
+        + ReceiptProvider<Receipt = Receipt>
+        + HeaderProvider
+        + BlockIdReader
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    /// Fetch the next batch of blocks from the DB.
+    ///
+    /// Returns `Ok(None)` when the cursor has passed the finalized block
+    /// (backfill complete). Otherwise reads up to `batch_size` blocks
+    /// starting at `cursor` and advances the cursor.
+    #[instrument(
+        name = "db_backfill.next_batch",
+        skip(self),
+        fields(from = self.cursor, to, batch_size = self.batch_size),
+        level = "info"
+    )]
+    pub(crate) async fn next_batch(&mut self) -> Result<Option<DbChainSegment>, RethHostError> {
+        let finalized = match self.provider.finalized_block_number()? {
+            Some(n) => n,
+            None => return Ok(None),
+        };
+
+        if self.cursor > finalized {
+            return Ok(None);
+        }
+
+        let from = self.cursor;
+        let to = finalized.min(self.cursor + self.batch_size - 1);
+
+        tracing::Span::current().record("to", to);
+
+        let provider = self.provider.clone();
+        let start = Instant::now();
+
+        let segment = tokio::task::spawn_blocking(move || read_block_range(&provider, from, to))
+            .await
+            .expect("spawn_blocking panicked")?;
+
+        let duration = start.elapsed();
+        let block_count = segment.len() as u64;
+
+        metrics::record_backfill_batch(block_count, duration);
+        metrics::set_backfill_cursor(to + 1);
+
+        self.cursor = to + 1;
+
+        debug!(block_count, cursor = self.cursor, "backfill batch complete");
+
+        Ok(Some(segment))
+    }
+}
+
+/// Read blocks and receipts for `from..=to` from the provider.
+///
+/// Extracted from [`DbBackfill::next_batch`] so it can be called inside
+/// `spawn_blocking` with a synchronous provider.
+fn read_block_range<P>(provider: &P, from: u64, to: u64) -> Result<DbChainSegment, RethHostError>
+where
+    P: BlockReader<Block = Block<TransactionSigned>> + ReceiptProvider<Receipt = Receipt>,
+{
+    let mut blocks = Vec::with_capacity((to - from + 1) as usize);
+    let mut prev_hash: Option<alloy::primitives::B256> = None;
+
+    for number in from..=to {
+        let block = provider
+            .recovered_block(number.into(), TransactionVariant::WithHash)?
+            .ok_or(RethHostError::MissingBlock(number))?;
+
+        debug_assert!(
+            prev_hash.is_none_or(|h| block.parent_hash() == h),
+            "parent hash continuity violated at block {number}"
+        );
+        prev_hash = Some(block.sealed_block().hash());
+
+        let receipts = provider
+            .receipts_by_block(number.into())?
+            .ok_or(RethHostError::MissingReceipts(number))?;
+
+        blocks.push(DbBlock { block, receipts });
+    }
+
+    Ok(DbChainSegment(blocks))
+}

--- a/crates/host-reth/src/backfill.rs
+++ b/crates/host-reth/src/backfill.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)] // used in subsequent tasks (HostChain enum, RethHostNotifier rewrite)
-
 use crate::{RecoveredBlockShim, error::RethHostError, metrics};
 use alloy::consensus::{Block, BlockHeader};
 use reth::primitives::{Receipt, RecoveredBlock};

--- a/crates/host-reth/src/backfill.rs
+++ b/crates/host-reth/src/backfill.rs
@@ -29,7 +29,7 @@ pub(crate) struct DbBlock {
 /// Implements [`Extractable`] using the same `RecoveredBlockShim` transmute
 /// pattern as [`RethChain`](crate::RethChain).
 #[derive(Debug)]
-pub(crate) struct DbChainSegment(Vec<DbBlock>);
+pub struct DbChainSegment(Vec<DbBlock>);
 
 impl Extractable for DbChainSegment {
     type Block = RecoveredBlockShim;

--- a/crates/host-reth/src/chain.rs
+++ b/crates/host-reth/src/chain.rs
@@ -84,3 +84,53 @@ impl Extractable for RethChain {
         self.inner.len()
     }
 }
+
+/// Unifies DB-backfill and live ExEx chain segments.
+///
+/// During startup, the notifier emits `Backfill` segments read directly
+/// from the reth DB. Once backfill is complete, it switches to `Live`
+/// segments from the ExEx notification stream. Both variants implement
+/// [`Extractable`] so the node processes them identically.
+#[derive(Debug)]
+pub enum HostChain {
+    /// A segment read from the reth DB during backfill.
+    Backfill(crate::backfill::DbChainSegment),
+    /// A segment from the live ExEx notification stream.
+    Live(RethChain),
+}
+
+impl Extractable for HostChain {
+    type Block = RecoveredBlockShim;
+    type Receipt = reth::primitives::Receipt;
+
+    fn blocks_and_receipts(
+        &self,
+    ) -> impl Iterator<Item = BlockAndReceipts<'_, Self::Block, Self::Receipt>> {
+        match self {
+            Self::Backfill(segment) => Box::new(segment.blocks_and_receipts())
+                as Box<dyn Iterator<Item = BlockAndReceipts<'_, Self::Block, Self::Receipt>>>,
+            Self::Live(chain) => Box::new(chain.blocks_and_receipts()),
+        }
+    }
+
+    fn first_number(&self) -> u64 {
+        match self {
+            Self::Backfill(segment) => segment.first_number(),
+            Self::Live(chain) => chain.first_number(),
+        }
+    }
+
+    fn tip_number(&self) -> u64 {
+        match self {
+            Self::Backfill(segment) => segment.tip_number(),
+            Self::Live(chain) => chain.tip_number(),
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Backfill(segment) => segment.len(),
+            Self::Live(chain) => chain.len(),
+        }
+    }
+}

--- a/crates/host-reth/src/error.rs
+++ b/crates/host-reth/src/error.rs
@@ -15,6 +15,12 @@ pub enum RethHostError {
     /// A required header was missing from the provider.
     #[error("missing header for block {0}")]
     MissingHeader(u64),
+    /// A required block was missing from the provider during DB backfill.
+    #[error("missing block at number {0}")]
+    MissingBlock(u64),
+    /// Receipts were missing for a block during DB backfill.
+    #[error("missing receipts for block {0}")]
+    MissingReceipts(u64),
 }
 
 impl RethHostError {

--- a/crates/host-reth/src/lib.rs
+++ b/crates/host-reth/src/lib.rs
@@ -22,6 +22,8 @@ pub use error::RethHostError;
 
 mod metrics;
 
+mod backfill;
+
 mod chain;
 pub use chain::RethChain;
 

--- a/crates/host-reth/src/lib.rs
+++ b/crates/host-reth/src/lib.rs
@@ -23,9 +23,10 @@ pub use error::RethHostError;
 mod metrics;
 
 mod backfill;
+pub use backfill::DbChainSegment;
 
 mod chain;
-pub use chain::RethChain;
+pub use chain::{HostChain, RethChain};
 
 mod config;
 pub use config::{rpc_config_from_args, serve_config_from_args};

--- a/crates/host-reth/src/lib.rs
+++ b/crates/host-reth/src/lib.rs
@@ -20,6 +20,8 @@ pub use blob_source::RethBlobSource;
 mod error;
 pub use error::RethHostError;
 
+mod metrics;
+
 mod chain;
 pub use chain::RethChain;
 

--- a/crates/host-reth/src/metrics.rs
+++ b/crates/host-reth/src/metrics.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)] // used in subsequent tasks (DbBackfill)
+
 use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
 use std::{sync::OnceLock, time::Duration};
 

--- a/crates/host-reth/src/metrics.rs
+++ b/crates/host-reth/src/metrics.rs
@@ -1,0 +1,32 @@
+use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
+use std::{sync::OnceLock, time::Duration};
+
+const BLOCKS_FETCHED: &str = "host_reth.db_backfill.blocks_fetched";
+const BATCHES_COMPLETED: &str = "host_reth.db_backfill.batches_completed";
+const BATCH_DURATION: &str = "host_reth.db_backfill.batch_duration_ms";
+const CURSOR_POSITION: &str = "host_reth.db_backfill.cursor";
+
+static DESCRIBED: OnceLock<()> = OnceLock::new();
+
+fn ensure_described() {
+    DESCRIBED.get_or_init(|| {
+        describe_counter!(BLOCKS_FETCHED, "Total blocks read from DB during backfill");
+        describe_counter!(BATCHES_COMPLETED, "DB backfill batches completed");
+        describe_histogram!(BATCH_DURATION, "DB backfill batch duration (ms)");
+        describe_gauge!(CURSOR_POSITION, "Current DB backfill cursor position");
+    });
+}
+
+/// Record a completed backfill batch.
+pub(crate) fn record_backfill_batch(blocks: u64, duration: Duration) {
+    ensure_described();
+    counter!(BLOCKS_FETCHED).increment(blocks);
+    counter!(BATCHES_COMPLETED).increment(1);
+    histogram!(BATCH_DURATION).record(duration.as_secs_f64() * 1000.0);
+}
+
+/// Update the backfill cursor gauge.
+pub(crate) fn set_backfill_cursor(position: u64) {
+    ensure_described();
+    gauge!(CURSOR_POSITION).set(position as f64);
+}

--- a/crates/host-reth/src/metrics.rs
+++ b/crates/host-reth/src/metrics.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)] // used in subsequent tasks (DbBackfill)
-
 use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
 use std::{sync::OnceLock, time::Duration};
 

--- a/crates/host-reth/src/notifier.rs
+++ b/crates/host-reth/src/notifier.rs
@@ -17,7 +17,7 @@ use signet_node_types::{HostNotification, HostNotificationKind, HostNotifier, Re
 use signet_rpc::{ServeConfig, StorageRpcConfig};
 use signet_types::primitives::TransactionSigned;
 use std::sync::Arc;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 /// Reth ExEx implementation of [`HostNotifier`].
 ///
@@ -151,30 +151,20 @@ where
                 Ok(None) => {
                     // Backfill complete. The cursor points to the next block
                     // to read, so the last backfilled block is cursor - 1.
+                    // `DbBackfill` just read this block from the same
+                    // provider, so the header must be present — a missing
+                    // header here is a DB-level failure, not a startup race.
                     let backfill = self.backfill.take().expect("backfill was Some");
                     let last_backfilled = backfill.cursor().saturating_sub(1);
 
-                    let head = self
-                        .provider
-                        .sealed_header(last_backfilled)
-                        .inspect_err(|e| {
-                            error!(last_backfilled, %e, "failed to look up header after backfill");
-                        })
-                        .expect("failed to look up header after backfill")
-                        .map(|h| BlockNumHash { number: last_backfilled, hash: h.hash() })
-                        .unwrap_or_else(|| {
-                            debug!(
-                                last_backfilled,
-                                "header not found after backfill, falling back to genesis"
-                            );
-                            let genesis = self
-                                .provider
-                                .sealed_header(0)
-                                .inspect_err(|e| error!(%e, "failed to look up genesis header"))
-                                .expect("failed to look up genesis header")
-                                .expect("genesis header missing");
-                            BlockNumHash { number: 0, hash: genesis.hash() }
-                        });
+                    let header = match self.provider.sealed_header(last_backfilled) {
+                        Ok(Some(h)) => h,
+                        Ok(None) => {
+                            return Some(Err(RethHostError::MissingHeader(last_backfilled)));
+                        }
+                        Err(e) => return Some(Err(e.into())),
+                    };
+                    let head = BlockNumHash { number: last_backfilled, hash: header.hash() };
 
                     info!(
                         last_backfilled,
@@ -246,11 +236,18 @@ where
     }
 
     fn set_backfill_thresholds(&mut self, max_blocks: Option<u64>) {
-        if let Some(backfill) = &mut self.backfill
-            && let Some(max_blocks) = max_blocks
-        {
-            debug!(max_blocks, "configured DB backfill batch size");
-            backfill.set_batch_size(max_blocks);
+        let Some(backfill) = &mut self.backfill else {
+            return;
+        };
+        match max_blocks {
+            Some(max_blocks) => {
+                debug!(max_blocks, "configured DB backfill batch size");
+                backfill.set_batch_size(max_blocks);
+            }
+            None => {
+                debug!("reset DB backfill batch size to default");
+                backfill.reset_batch_size();
+            }
         }
     }
 

--- a/crates/host-reth/src/notifier.rs
+++ b/crates/host-reth/src/notifier.rs
@@ -1,5 +1,6 @@
 use crate::{
-    RethChain,
+    backfill::DbBackfill,
+    chain::HostChain,
     config::{rpc_config_from_args, serve_config_from_args},
     error::RethHostError,
 };
@@ -7,16 +8,16 @@ use alloy::{consensus::BlockHeader, eips::BlockNumHash};
 use futures_util::StreamExt;
 use reth::{
     chainspec::EthChainSpec,
-    primitives::EthPrimitives,
-    providers::{BlockIdReader, HeaderProvider},
+    primitives::{EthPrimitives, Receipt},
+    providers::{BlockIdReader, BlockReader, HeaderProvider, ReceiptProvider},
 };
 use reth_exex::{ExExContext, ExExEvent, ExExNotifications, ExExNotificationsStream};
 use reth_node_api::{FullNodeComponents, NodeTypes};
-use reth_stages_types::ExecutionStageThresholds;
 use signet_node_types::{HostNotification, HostNotificationKind, HostNotifier, RevertRange};
 use signet_rpc::{ServeConfig, StorageRpcConfig};
+use signet_types::primitives::TransactionSigned;
 use std::sync::Arc;
-use tracing::{debug, error};
+use tracing::{debug, error, info, warn};
 
 /// Reth ExEx implementation of [`HostNotifier`].
 ///
@@ -26,6 +27,8 @@ pub struct RethHostNotifier<Host: FullNodeComponents> {
     notifications: ExExNotifications<Host::Provider, Host::Evm>,
     provider: Host::Provider,
     events: tokio::sync::mpsc::UnboundedSender<ExExEvent>,
+    backfill: Option<DbBackfill<Host::Provider>>,
+    head_set: bool,
 }
 
 impl<Host: FullNodeComponents> core::fmt::Debug for RethHostNotifier<Host> {
@@ -92,8 +95,13 @@ where
     let pool = ctx.pool().clone();
     let provider = ctx.provider().clone();
 
-    let notifier =
-        RethHostNotifier { notifications: ctx.notifications, provider, events: ctx.events };
+    let notifier = RethHostNotifier {
+        notifications: ctx.notifications,
+        provider,
+        events: ctx.events,
+        backfill: None,
+        head_set: false,
+    };
 
     DecomposedContext { notifier, serve_config, rpc_config, pool, chain_name }
 }
@@ -102,20 +110,92 @@ impl<Host> HostNotifier for RethHostNotifier<Host>
 where
     Host: FullNodeComponents,
     Host::Types: NodeTypes<Primitives = EthPrimitives>,
+    Host::Provider: BlockReader<Block = alloy::consensus::Block<TransactionSigned>>
+        + ReceiptProvider<Receipt = Receipt>,
 {
-    type Chain = RethChain;
+    type Chain = HostChain;
     type Error = RethHostError;
 
     async fn next_notification(
         &mut self,
     ) -> Option<Result<HostNotification<Self::Chain>, Self::Error>> {
+        // Phase 1: DB backfill — drain batches until complete.
+        if let Some(backfill) = &mut self.backfill {
+            match backfill.next_batch().await {
+                Ok(Some(segment)) => {
+                    let safe_block_number = self
+                        .provider
+                        .safe_block_number()
+                        .inspect_err(|e| {
+                            debug!(%e, "failed to read safe block number from provider");
+                        })
+                        .ok()
+                        .flatten();
+                    let finalized_block_number = self
+                        .provider
+                        .finalized_block_number()
+                        .inspect_err(|e| {
+                            debug!(%e, "failed to read finalized block number from provider");
+                        })
+                        .ok()
+                        .flatten();
+
+                    return Some(Ok(HostNotification {
+                        kind: HostNotificationKind::ChainCommitted {
+                            new: Arc::new(HostChain::Backfill(segment)),
+                        },
+                        safe_block_number,
+                        finalized_block_number,
+                    }));
+                }
+                Ok(None) => {
+                    // Backfill complete. The cursor points to the next block
+                    // to read, so the last backfilled block is cursor - 1.
+                    let backfill = self.backfill.take().expect("backfill was Some");
+                    let last_backfilled = backfill.cursor().saturating_sub(1);
+
+                    let head = self
+                        .provider
+                        .sealed_header(last_backfilled)
+                        .inspect_err(|e| {
+                            error!(last_backfilled, %e, "failed to look up header after backfill");
+                        })
+                        .expect("failed to look up header after backfill")
+                        .map(|h| BlockNumHash { number: last_backfilled, hash: h.hash() })
+                        .unwrap_or_else(|| {
+                            debug!(
+                                last_backfilled,
+                                "header not found after backfill, falling back to genesis"
+                            );
+                            let genesis = self
+                                .provider
+                                .sealed_header(0)
+                                .inspect_err(|e| error!(%e, "failed to look up genesis header"))
+                                .expect("failed to look up genesis header")
+                                .expect("genesis header missing");
+                            BlockNumHash { number: 0, hash: genesis.hash() }
+                        });
+
+                    info!(
+                        last_backfilled,
+                        head_number = head.number,
+                        "DB backfill complete, switching to live ExEx notifications"
+                    );
+
+                    self.notifications.set_with_head(reth_exex::ExExHead { block: head });
+                    // Fall through to phase 2.
+                }
+                Err(e) => return Some(Err(e)),
+            }
+        }
+
+        // Phase 2: live ExEx notifications.
         let notification = self.notifications.next().await?;
         let notification = match notification {
             Ok(n) => n,
             Err(e) => return Some(Err(RethHostError::notification(e))),
         };
 
-        // Read safe/finalized from the provider at notification time.
         let safe_block_number = self
             .provider
             .safe_block_number()
@@ -135,7 +215,9 @@ where
 
         let kind = match notification {
             reth_exex::ExExNotification::ChainCommitted { new } => {
-                HostNotificationKind::ChainCommitted { new: Arc::new(RethChain::new(new)) }
+                HostNotificationKind::ChainCommitted {
+                    new: Arc::new(HostChain::Live(crate::RethChain::new(new))),
+                }
             }
             reth_exex::ExExNotification::ChainReverted { old } => {
                 let old = RevertRange::new(old.first().number(), old.tip().number());
@@ -143,7 +225,10 @@ where
             }
             reth_exex::ExExNotification::ChainReorged { old, new } => {
                 let old = RevertRange::new(old.first().number(), old.tip().number());
-                HostNotificationKind::ChainReorged { old, new: Arc::new(RethChain::new(new)) }
+                HostNotificationKind::ChainReorged {
+                    old,
+                    new: Arc::new(HostChain::Live(crate::RethChain::new(new))),
+                }
             }
         };
 
@@ -151,38 +236,22 @@ where
     }
 
     fn set_head(&mut self, block_number: u64) {
-        let head = self
-            .provider
-            .sealed_header(block_number)
-            .inspect_err(|e| error!(block_number, %e, "failed to look up header for set_head"))
-            .expect("failed to look up header for set_head")
-            .map(|h| BlockNumHash { number: block_number, hash: h.hash() })
-            .unwrap_or_else(|| {
-                debug!(block_number, "header not found for set_head, falling back to genesis");
-                let genesis = self
-                    .provider
-                    .sealed_header(0)
-                    .inspect_err(|e| error!(%e, "failed to look up genesis header"))
-                    .expect("failed to look up genesis header")
-                    .expect("genesis header missing");
-                BlockNumHash { number: 0, hash: genesis.hash() }
-            });
-
-        self.notifications.set_with_head(reth_exex::ExExHead { block: head });
+        if self.head_set {
+            warn!(block_number, "set_head called more than once, ignoring");
+            return;
+        }
+        self.head_set = true;
+        info!(block_number, "initiating DB backfill");
+        self.backfill = Some(DbBackfill::new(self.provider.clone(), block_number));
     }
 
     fn set_backfill_thresholds(&mut self, max_blocks: Option<u64>) {
-        let thresholds = match max_blocks {
-            Some(max_blocks) => {
-                debug!(max_blocks, "configured backfill thresholds");
-                ExecutionStageThresholds { max_blocks: Some(max_blocks), ..Default::default() }
-            }
-            None => {
-                debug!("reset backfill thresholds to defaults");
-                ExecutionStageThresholds::default()
-            }
-        };
-        self.notifications.set_backfill_thresholds(thresholds);
+        if let Some(backfill) = &mut self.backfill
+            && let Some(max_blocks) = max_blocks
+        {
+            debug!(max_blocks, "configured DB backfill batch size");
+            backfill.set_batch_size(max_blocks);
+        }
     }
 
     fn send_finished_height(&self, block_number: u64) -> Result<(), Self::Error> {

--- a/crates/host-rpc/src/notifier.rs
+++ b/crates/host-rpc/src/notifier.rs
@@ -93,6 +93,9 @@ pub struct RpcHostNotifier<P> {
 
     /// Genesis timestamp, used for epoch calculation.
     genesis_timestamp: u64,
+
+    /// Whether `set_head` has been called.
+    head_set: bool,
 }
 
 impl<P> core::fmt::Debug for RpcHostNotifier<P> {
@@ -103,6 +106,7 @@ impl<P> core::fmt::Debug for RpcHostNotifier<P> {
             .field("max_rpc_concurrency", &self.max_rpc_concurrency)
             .field("backfill_from", &self.backfill_from)
             .field("last_emitted", &self.last_emitted)
+            .field("head_set", &self.head_set)
             .finish_non_exhaustive()
     }
 }
@@ -135,6 +139,7 @@ where
             last_emitted: None,
             slot_seconds,
             genesis_timestamp,
+            head_set: false,
         }
     }
 
@@ -645,6 +650,11 @@ where
     }
 
     fn set_head(&mut self, block_number: u64) {
+        if self.head_set {
+            tracing::warn!(block_number, "set_head called more than once, ignoring");
+            return;
+        }
+        self.head_set = true;
         self.backfill_from = Some(block_number);
         self.last_emitted = None;
     }

--- a/crates/node-types/src/notifier.rs
+++ b/crates/node-types/src/notifier.rs
@@ -16,10 +16,11 @@ use signet_extract::Extractable;
 ///
 /// Implementations must uphold the following contract:
 ///
-/// 1. **`set_head`** — called once at startup before the first
-///    [`next_notification`]. The backend must resolve the block number to a
-///    hash (falling back to genesis if the number is not yet available) and
-///    begin delivering notifications from that point.
+/// 1. **`set_head`** — called exactly once at startup before the first
+///    [`next_notification`]. Subsequent calls are silently ignored. The
+///    backend must resolve the block number to a hash (falling back to
+///    genesis if the number is not yet available) and begin delivering
+///    notifications from that point.
 /// 2. **`next_notification`** — must yield notifications in host-chain order.
 ///    Returning `None` signals a clean shutdown.
 /// 3. **`set_backfill_thresholds`** — may be called at any time. Passing
@@ -44,6 +45,11 @@ pub trait HostNotifier: Send + Sync {
 
     /// Set the head position, requesting backfill from this block number.
     /// The backend resolves the block number to a block hash internally.
+    ///
+    /// This must be called exactly once before the first
+    /// [`next_notification`]. Subsequent calls are silently ignored.
+    ///
+    /// [`next_notification`]: HostNotifier::next_notification
     fn set_head(&mut self, block_number: u64);
 
     /// Configure backfill batch size limits. `None` means use the backend's


### PR DESCRIPTION
## Summary

- Replace ExEx-driven backfill (which re-executes blocks) with direct DB reads from the reth provider, fixing slow startup and memory issues
- New `DbBackfill<P>` reads blocks+receipts in batches up to finalized, then hands off to the ExEx stream for live blocks
- `HostChain` enum unifies backfill and live chain segments behind `Extractable`
- `set_head` documented and enforced as once-only across both notifier implementations

## Details

The ExEx backfill mechanism re-executes historical blocks on startup, which is slow and has caused memory issues. The reth DB already contains executed results, making re-execution unnecessary.

**New types** (`signet-host-reth`):
- `DbBlock` / `DbChainSegment` — owned block+receipts from DB, implements `Extractable`
- `DbBackfill<P>` — batch reader using `spawn_blocking` for MDBX reads
- `HostChain` — enum wrapping `DbChainSegment` (backfill) and `RethChain` (live)

**Notifier changes:**
- `RethHostNotifier::next_notification` is now two-phase: drain DB backfill, then switch to ExEx
- `set_head` creates a `DbBackfill` instead of calling ExEx `set_with_head`
- ExEx stream is initiated after backfill completes, pointed at the last backfilled block
- `reth-stages-types` dependency removed

**Cross-crate:**
- `HostNotifier::set_head` trait doc clarified as once-only
- `RpcHostNotifier::set_head` guards against repeated calls

## Review follow-ups

- **Fraser**: `set_backfill_thresholds(None)` now resets to `DEFAULT_BATCH_SIZE` via a new `DbBackfill::reset_batch_size`, matching the trait contract and `RpcHostNotifier`.
- **Evalir**: Removed the genesis fallback after backfill completion. The ExEx startup race it was defending against was fixed upstream in reth (#19665 / #22168, merged Feb 2026), and at our call site `DbBackfill` has just successfully read `last_backfilled` from the same provider — so a missing header there now indicates DB-level failure and returns `RethHostError::MissingHeader`.

Closes ENG-1784

## Test plan

- [x] `cargo clippy` passes (both `--all-features` and `--no-default-features`)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc` passes
- [x] All existing tests pass (`signet-host-reth`, `signet-node-types`, `signet-host-rpc`)
- [x] `signet-node` compiles cleanly with new `HostChain` type
- [ ] Integration test on a reth node with historical data (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)