### PR TITLE
chore: ignore new audit warnings

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -27,4 +27,16 @@ ignore = [
     # logger calls `rand::rng()` during reseeding. Our 0.8.5 (transitive via alloy-consensus)
     # has neither feature enabled; our 0.9.4 is already patched.
     "RUSTSEC-2026-0097",
+
+    # `hickory-proto` 0.25.2 NSEC3 closest-encloser proof validation unbounded loop on cross-zone
+    # responses. No fixed upgrade is available. Transitive dep via reth's `reth-dns-discovery` ->
+    # `hickory-resolver`. node-components does not perform DNSSEC validation, so this code path is
+    # unused.
+    "RUSTSEC-2026-0118",
+
+    # `hickory-proto` 0.25.2 O(n²) name-compression CPU exhaustion during message encoding. Fix is
+    # in 0.26.1, but `hickory-resolver` 0.25.2 (pinned by reth's `reth-dns-discovery`) requires
+    # `hickory-proto ^0.25`, so we can't upgrade until reth bumps. node-components does not encode
+    # DNS messages.
+    "RUSTSEC-2026-0119",
 ]


### PR DESCRIPTION
Added [RUSTSEC-2026-0118](https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-3v94-mw7p-v465) and [RUSTSEC-2026-0119](https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-q2qq-hmj6-3wpp) to the `ignore` list along with the rationale for each.