### PR TITLE
chore: exclude rocksdb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,15 @@ alloy = { version = "1.4.0", features = [
 ] }
 
 # Reth
-reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
+reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false, features = [
+    "jemalloc",
+    "otlp",
+    "otlp-logs",
+    "js-tracer",
+    "keccak-cache-global",
+    "asm-keccak",
+    "min-debug-logs",
+] }
 reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
 reth-exex = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
 reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
@@ -116,4 +124,3 @@ url = "2.5.4"
 
 # Test Utils
 tempfile = "3.17.0"
-


### PR DESCRIPTION
## Summary

- Drop the transitive `rocksdb` dependency from our build by disabling default features on the workspace `reth` dep and re-listing the upstream defaults except `rocksdb`.
- `rocksdb` was pulled in via `reth` → `reth-provider` (gated behind `reth-provider/rocksdb`, which `reth`'s `default` feature enables). We don't use the rocksdb-backed provider paths, so this is dead weight - a heavy C++/bindgen build for no runtime benefit.

## Changes

`Cargo.toml`: workspace `reth` dep now uses `default-features = false` with an explicit feature list (`jemalloc`, `otlp`, `otlp-logs`, `js-tracer`, `keccak-cache-global`, `asm-keccak`, `min-debug-logs`) - i.e. upstream's `default` array minus `rocksdb`.

Note: `reth-revm/portable` is in upstream's `default` array but is a sub-crate feature directive that can't be re-listed by a consumer. If anything relied on portable revm it would need to be re-enabled via a separate path; nothing in this workspace appears to.